### PR TITLE
debug[Docker]:  upgrade openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY ./ /app/
 RUN npm -v && \
     apt update && \
     apt install git-all -y && \
+    apt upgrade openssl -y && \
     npm install -g npm@latest && \
     npm install
 


### PR DESCRIPTION
-prisma:warn Prisma failed to detect the libssl/openssl version to use, and may not work as expected. Defaulting to "openssl-1.1.x". と怒られるので、Dockerfileでupgradeする。